### PR TITLE
Concept note on Access Right "annotate" in special strings

### DIFF
--- a/docsrc/imap/concepts/overview_and_concepts.rst
+++ b/docsrc/imap/concepts/overview_and_concepts.rst
@@ -161,8 +161,8 @@ These are referred to as *negative rights*.
 Special Strings
 ===============
 
-The ACL may be combined of the special strings none, read (lrs), post (lrsp), append (lrsip), write(lrswipkxte), delete (lrxte), or all (lrswipkxte), or any combinations of the ACL codes when using the setacl methods 
-:ref:`imap-reference-manpages-systemcommands-cyradm-setaclmailbox`
+The ACL may be combined of the special strings none, read (``lrs``), post (``lrsp``), append (``lrsip``), write(``lrswipkxte``), delete (``lrxte``), or all (``lrswipkxte``), or any combinations of the ACL codes when using the setacl methods :ref:`imap-reference-manpages-systemcommands-cyradm-setaclmailbox`.
+The annotate Access Right ``n`` is not part of the special strings. 
 
 Calculating a Users' Rights
 ===========================


### PR DESCRIPTION
Concept note on Access Rights and special strings. The annotate flag was missing in the previous commit. 

The ACL may be combined of the special strings none, read (``lrs``), post (``lrsp``), append (``lrsip``), write(``lrswipkxte``), delete (``lrxte``), or all (``lrswipkxte``), or any combinations of the ACL codes when using the setacl methods :ref:`imap-reference-manpages-systemcommands-cyradm-setaclmailbox`. The annotate Access Right ``n`` is not part of the special strings. 